### PR TITLE
Changing Redirect to MixinExtra WrapOperation

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -27,6 +27,8 @@ minecraft {
 dependencies {
     compileOnly group:'org.spongepowered', name:'mixin', version:'0.8.5'
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.1'
+    implementation("com.github.llamalad7.mixinextras:mixinextras-common:0.2.0-rc.3")
+    annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-common:0.2.0-rc.3")
 }
 sourceSets.main.resources.srcDir './src/generated/resources'
 processResources {

--- a/Common/src/main/java/com/nyfaria/nyfsspiders/mixin/EntityMixin.java
+++ b/Common/src/main/java/com/nyfaria/nyfsspiders/mixin/EntityMixin.java
@@ -1,5 +1,7 @@
 package com.nyfaria.nyfsspiders.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.nyfaria.nyfsspiders.common.CommonEventHandlers;
 import com.nyfaria.nyfsspiders.common.entity.mob.IEntityMovementHook;
 import com.nyfaria.nyfsspiders.common.entity.mob.IEntityReadWriteHook;
@@ -72,8 +74,8 @@ public abstract class EntityMixin implements IEntityMovementHook, IEntityReadWri
 //	private void onCanTriggerWalking(CallbackInfoReturnable<Boolean> ci) {
 //		ci.setReturnValue(this.getAdjustedCanTriggerWalking(ci.getReturnValue()));
 //	}
-	@Redirect(method = "move", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity$MovementEmission;emitsAnything()Z"))
-	public boolean bop(Entity.MovementEmission instance){
+	@WrapOperation(method = "move", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity$MovementEmission;emitsAnything()Z"))
+	public boolean bop(Entity.MovementEmission instance, Operation<Boolean> original){
 		return this.getAdjustedCanTriggerWalking(instance.emitsAnything());
 	}
 

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.1'
     implementation project(":Common")
+    include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.2.0-rc.3")))
 }
 
 loom {

--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -12,7 +12,7 @@ archivesBaseName = "${mod_id}-forge-${minecraft_version}"
 
 minecraft {
     mappings channel: mappings_channel, version: mappings_version
-
+    jarJar.enable()
     if (project.hasProperty('forge_ats_enabled') && project.findProperty('forge_ats_enabled').toBoolean()) {
         // This location is hardcoded in Forge and can not be changed.
         // https://github.com/MinecraftForge/MinecraftForge/blob/be1698bb1554f9c8fa2f58e32b9ab70bc4385e60/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java#L123

--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -79,6 +79,10 @@ mixin {
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     compileOnly project(":Common")
+    implementation(annotationProcessor("io.github.llamalad7:mixinextras-common:0.2.0-rc.3"))
+    implementation(jarJar("io.github.llamalad7:mixinextras-forge:0.2.0-rc.3")) {
+        jarJar.ranged(it, "[0.2.0-rc.3,)")
+    }
     annotationProcessor "org.spongepowered:mixin:${mixin_version}:processor"
 }
 


### PR DESCRIPTION
This prevents any mixin-related crashes if another mod tries and modifies the same method since you are currently redirecting it. Does require Mixin Extras, which I have added to each build.gradle now with Fabric including it and Forge Jar-in-Jaring it.

More info about WrapOperation here: https://github.com/LlamaLad7/MixinExtras/wiki/WrapOperation