### PR TITLE
To disable Spider Jockey spawning

### DIFF
--- a/Common/src/main/java/com/nyfaria/nyfsspiders/mixin/BetterSpiderEntityMixin.java
+++ b/Common/src/main/java/com/nyfaria/nyfsspiders/mixin/BetterSpiderEntityMixin.java
@@ -69,6 +69,18 @@ public abstract class BetterSpiderEntityMixin extends Monster implements IClimbe
 		}
 	}
 
+	@Redirect(
+			method = "finalizeSpawn",
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/util/RandomSource;nextInt(I)I",
+					ordinal = 0
+			)
+	)
+	private int redirectRandomCheck(RandomSource random, int bound) {
+		return 1;
+	}
+	
 	@Override
 	public boolean shouldTrackPathingTargets() {
 		return this.pathFinderDebugPreview;


### PR DESCRIPTION
### Problem  
The skeleton entity fails to synchronize rotation with its mounted spider, causing misaligned collision boxes.   This leads to the skeleton clipping into walls during climbing animations.
(Note: I have disabled Spider Jockey spawning via Mixin to avoid immersion-breaking issues.)
### Reproduction Steps  
1. Spawn a Spider Jockey in a cave environment.  
2. Trigger spider climbing behavior near walls.  
3. Observe skeleton collision box intersecting with blocks.  
![SpiderJockey](https://github.com/user-attachments/assets/a3619c72-4e2e-46aa-a485-e1ced103055f)
