### PR TITLE
Fix isPositionClear force loading chunks exponentially

### DIFF
--- a/Common/src/main/java/com/nyfaria/nyfsspiders/common/entity/movement/AdvancedClimberPathNavigator.java
+++ b/Common/src/main/java/com/nyfaria/nyfsspiders/common/entity/movement/AdvancedClimberPathNavigator.java
@@ -461,7 +461,7 @@ public class AdvancedClimberPathNavigator<T extends Mob & IClimberEntity> extend
 
     protected boolean isPositionClear(int x, int y, int z, int sizeX, int sizeY, int sizeZ, Vec3 start, double dx, double dz, double minDotProduct, Direction.Axis ax, Direction.Axis ay, Direction.Axis az) {
         for (BlockPos pos : BlockPos.betweenClosed(new BlockPos(x, y, z), new BlockPos(x + sizeX - 1, y + sizeY - 1, z + sizeZ - 1))) {
-            if (level.isLoaded(pos)) continue;
+            if (!level.isLoaded(pos)) continue;
             double offsetX = swizzle(pos.getX(), pos.getY(), pos.getZ(), ax) + 0.5D - swizzle(start, ax);
             double pffsetZ = swizzle(pos.getX(), pos.getY(), pos.getZ(), az) + 0.5D - swizzle(start, az);
 


### PR DESCRIPTION
I'm not 100% sure about this line of code, but to me it very much seems like, it's checking non-loaded chunks for position checks, which forces those chunks to load (can be observed with spark having loaded 7000 chunks when just sitting at spawn in single-player with a bunch of spiders).

At least when testing, the spiders still move as they're supposed to and the previously observed lag is gone.

Other versions may also be affected.
